### PR TITLE
Fix for nav = no background

### DIFF
--- a/src/style/style.scss
+++ b/src/style/style.scss
@@ -14,4 +14,19 @@ html {
 body {
   margin: 0;
   padding: 0;
+
+  min-height: 100vh;
+  background-position: bottom;
+  transition: 0.4s;
+
+  background: linear-gradient(
+      180deg,
+      rgba(75, 24, 24, 0.58) 0%,
+      rgba(3, 13, 52, 0.5) 68.75%,
+      #141341 97.4%
+    ),
+    url("../assets/landing-bg.png");
+  box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+  background-size: 100%;
+  background-repeat: no-repeat;
 }


### PR DESCRIPTION
Since the navigation bar is transparent, and depends on the background of the page, I just set the body to the standard background image and gradient